### PR TITLE
add export command and data export functionality for source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ scratch
 
 # binary
 gh-migration-validator
+.exports/

--- a/README.md
+++ b/README.md
@@ -79,6 +79,67 @@ For GitHub Enterprise Server:
 export GHMV_SOURCE_HOSTNAME="https://github.example.com"
 ```
 
+## Export Functionality
+
+The tool also provides an export command to capture repository data at a specific point in time, which can be useful for creating snapshots before and after migrations.
+
+### Export Usage
+
+```bash
+gh migration-validator export \
+  --source-organization "source-org" \
+  --source-repo "my-repo" \
+  --source-token "ghp_xxx" \
+  --format json \
+  --output ".exports/my-export.json"
+```
+
+### Export Options
+
+- `--source-organization` (required): Source organization name
+- `--source-repo` (required): Source repository name  
+- `--source-token` (required): GitHub token with read permissions
+- `--source-hostname` (optional): GitHub Enterprise Server URL
+- `--format` (optional): Export format - `json` or `csv` (default: `json`)
+- `--output` (optional): Output file path (auto-generated if not specified)
+
+### Export Output Formats
+
+**JSON Format:**
+
+```json
+{
+  "export_timestamp": "2025-10-02T14:49:08Z",
+  "repository_data": {
+    "owner": "mona-actions",
+    "name": "my-repo",
+    "issues": 42,
+    "pull_requests": {
+      "open": 5,
+      "closed": 10, 
+      "merged": 15,
+      "total": 30
+    },
+    "tags": 8,
+    "releases": 3,
+    "commits": 150,
+    "latest_commit_sha": "abc123def456"
+  }
+}
+```
+
+**CSV Format:**
+
+Contains the same data in CSV format with headers for easy analysis in spreadsheet applications.
+
+### Default Export Location
+
+When no output file is specified, exports are automatically saved to `.exports/` directory with timestamped filenames:
+
+- `.exports/{owner}_{repo}_export_{timestamp}.{format}`
+
+Example: `.exports/mona-actions_my-repo_export_20251002_144908.json`
+
 ## What Gets Validated
 
 The tool compares the following metrics between source and target repositories:
@@ -99,9 +160,11 @@ The tool compares the following metrics between source and target repositories:
 ## Output Formats
 
 ### Console Output
+
 The tool provides a formatted table with colored status indicators and a summary.
 
 ### Markdown Output
+
 Use the `--markdown-table` flag to generate copy-paste ready markdown for documentation.
 
 ## Dependencies

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -1,0 +1,120 @@
+/*
+Copyright © 2025 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"fmt"
+	"mona-actions/gh-migration-validator/internal/export"
+	"mona-actions/gh-migration-validator/internal/validator"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// exportCmd represents the export command
+var exportCmd = &cobra.Command{
+	Use:   "export",
+	Short: "Export source repository data at a point in time",
+	Long: `Export repository data from the source organization at the current point in time.
+
+This command fetches and exports repository metadata including:
+- Issues count
+- Pull requests count (open, closed, merged)
+- Tags count
+- Releases count
+- Commits count
+- Latest commit hash
+
+The data can be exported in JSON or CSV format with a timestamp.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// Get parameters from flags
+		sourceOrganization := cmd.Flag("source-organization").Value.String()
+		sourceToken := cmd.Flag("source-token").Value.String()
+		ghHostname := cmd.Flag("source-hostname").Value.String()
+		sourceRepo := cmd.Flag("source-repo").Value.String()
+		outputFormat := cmd.Flag("format").Value.String()
+		outputFile := cmd.Flag("output").Value.String()
+
+		// Only set ENV variables if flag values are provided (not empty)
+		if sourceOrganization != "" {
+			os.Setenv("GHMV_SOURCE_ORGANIZATION", sourceOrganization)
+		}
+		if sourceToken != "" {
+			os.Setenv("GHMV_SOURCE_TOKEN", sourceToken)
+		}
+		if ghHostname != "" {
+			os.Setenv("GHMV_SOURCE_HOSTNAME", ghHostname)
+		}
+		if sourceRepo != "" {
+			os.Setenv("GHMV_SOURCE_REPO", sourceRepo)
+		}
+
+		// Bind ENV variables in Viper
+		viper.BindEnv("SOURCE_ORGANIZATION")
+		viper.BindEnv("SOURCE_TOKEN")
+		viper.BindEnv("SOURCE_HOSTNAME")
+		viper.BindEnv("SOURCE_PRIVATE_KEY")
+		viper.BindEnv("SOURCE_APP_ID")
+		viper.BindEnv("SOURCE_INSTALLATION_ID")
+		viper.BindEnv("SOURCE_REPO")
+
+		// Validate required variables for export
+		if err := checkExportVars(); err != nil {
+			fmt.Printf("Export configuration validation failed: %v\n", err)
+			os.Exit(1)
+		}
+
+		initializeAPI()
+
+		// Create validator and export source data
+		migrationValidator := validator.New(ghAPI)
+
+		// Export the source repository data
+		timestamp := time.Now()
+		err := export.ExportSourceData(migrationValidator, sourceOrganization, sourceRepo, outputFormat, outputFile, timestamp)
+		if err != nil {
+			fmt.Printf("Export failed: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	// Add export command to root
+	rootCmd.AddCommand(exportCmd)
+
+	// Define flags specific to export command
+	exportCmd.Flags().StringP("source-organization", "s", "", "Source Organization to export data from")
+	exportCmd.MarkFlagRequired("source-organization")
+
+	exportCmd.Flags().StringP("source-token", "a", "", "Source Organization GitHub token. Scopes: read:org, read:user, user:email")
+
+	exportCmd.Flags().StringP("source-hostname", "u", "", "GitHub Enterprise source hostname url (optional) Ex. https://github.example.com")
+
+	exportCmd.Flags().StringP("source-repo", "", "", "Source repository name to export (just the repo name, not owner/repo)")
+	exportCmd.MarkFlagRequired("source-repo")
+
+	exportCmd.Flags().StringP("format", "f", "json", "Output format: json or csv")
+
+	exportCmd.Flags().StringP("output", "o", "", "Output file path (if not provided, will use default naming)")
+}
+
+// checkExportVars validates the configuration for export command
+func checkExportVars() error {
+	// Check for source token
+	sourceToken := viper.GetString("SOURCE_TOKEN")
+	if sourceToken == "" {
+		return fmt.Errorf("source token is required. Set it via --source-token flag or GHMV_SOURCE_TOKEN environment variable")
+	}
+
+	// Check source repository
+	sourceRepo := viper.GetString("SOURCE_REPO")
+	if sourceRepo == "" {
+		return fmt.Errorf("source repository is required. Set it via --source-repo flag")
+	}
+
+	return nil
+}

--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -1,0 +1,166 @@
+package export
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"mona-actions/gh-migration-validator/internal/validator"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/pterm/pterm"
+)
+
+// ExportData represents the exported repository data with metadata
+type ExportData struct {
+	ExportTimestamp time.Time                `json:"export_timestamp"`
+	Repository      validator.RepositoryData `json:"repository_data"`
+}
+
+// ExportSourceData exports source repository data at a point in time
+// Takes a validator instance to leverage existing data retrieval functionality
+func ExportSourceData(mv *validator.MigrationValidator, owner, repoName, format, outputFile string, timestamp time.Time) error {
+	fmt.Println("Starting source repository data export...")
+	fmt.Printf("Repository: %s/%s\n", owner, repoName)
+
+	// Create a spinner for the export process
+	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Preparing to export data from %s/%s...", owner, repoName))
+
+	// Use the validator to retrieve source repository data
+	err := mv.RetrieveSourceData(owner, repoName, spinner)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve source data for export: %w", err)
+	}
+
+	// Prepare export data
+	exportData := ExportData{
+		ExportTimestamp: timestamp,
+		Repository:      *mv.SourceData,
+	}
+
+	// Generate output filename if not provided
+	if outputFile == "" {
+		outputFile = generateExportFileName(owner, repoName, format, timestamp)
+	}
+
+	// Export based on format
+	switch strings.ToLower(format) {
+	case "json":
+		err = exportToJSON(exportData, outputFile)
+	case "csv":
+		err = exportToCSV(exportData, outputFile)
+	default:
+		return fmt.Errorf("unsupported format: %s. Supported formats: json, csv", format)
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to export data: %w", err)
+	}
+
+	spinner.Success(fmt.Sprintf("Export completed successfully: %s", outputFile))
+	fmt.Println()
+	return nil
+}
+
+// generateExportFileName creates a default filename for the export in a .exports directory
+func generateExportFileName(owner, repo, format string, timestamp time.Time) string {
+	timestampStr := timestamp.Format("20060102_150405")
+	filename := fmt.Sprintf("%s_%s_export_%s.%s", owner, repo, timestampStr, format)
+	return filepath.Join(".exports", filename)
+}
+
+// exportToJSON exports data to JSON format
+func exportToJSON(data ExportData, filename string) error {
+	// Create directory if it doesn't exist
+	if dir := filepath.Dir(filename); dir != "." {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("failed to create directory %s: %w", dir, err)
+		}
+	}
+
+	file, err := os.Create(filename)
+	if err != nil {
+		return fmt.Errorf("failed to create JSON file: %w", err)
+	}
+	defer file.Close()
+
+	encoder := json.NewEncoder(file)
+	encoder.SetIndent("", "  ")
+
+	if err := encoder.Encode(data); err != nil {
+		return fmt.Errorf("failed to encode JSON: %w", err)
+	}
+
+	return nil
+}
+
+// exportToCSV exports data to CSV format
+func exportToCSV(data ExportData, filename string) error {
+	// Create directory if it doesn't exist
+	if dir := filepath.Dir(filename); dir != "." {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("failed to create directory %s: %w", dir, err)
+		}
+	}
+
+	file, err := os.Create(filename)
+	if err != nil {
+		return fmt.Errorf("failed to create CSV file: %w", err)
+	}
+	defer file.Close()
+
+	writer := csv.NewWriter(file)
+	defer writer.Flush()
+
+	// Write CSV header
+	header := []string{
+		"export_timestamp",
+		"owner",
+		"repository_name",
+		"issues_count",
+		"pull_requests_open",
+		"pull_requests_closed",
+		"pull_requests_merged",
+		"pull_requests_total",
+		"tags_count",
+		"releases_count",
+		"commits_count",
+		"latest_commit_sha",
+	}
+	if err := writer.Write(header); err != nil {
+		return fmt.Errorf("failed to write CSV header: %w", err)
+	}
+
+	// Write data row
+	var prOpen, prClosed, prMerged, prTotal string
+	if data.Repository.PRs != nil {
+		prOpen = fmt.Sprintf("%d", data.Repository.PRs.Open)
+		prClosed = fmt.Sprintf("%d", data.Repository.PRs.Closed)
+		prMerged = fmt.Sprintf("%d", data.Repository.PRs.Merged)
+		prTotal = fmt.Sprintf("%d", data.Repository.PRs.Total)
+	} else {
+		prOpen, prClosed, prMerged, prTotal = "0", "0", "0", "0"
+	}
+
+	record := []string{
+		data.ExportTimestamp.Format(time.RFC3339),
+		data.Repository.Owner,
+		data.Repository.Name,
+		fmt.Sprintf("%d", data.Repository.Issues),
+		prOpen,
+		prClosed,
+		prMerged,
+		prTotal,
+		fmt.Sprintf("%d", data.Repository.Tags),
+		fmt.Sprintf("%d", data.Repository.Releases),
+		fmt.Sprintf("%d", data.Repository.CommitCount),
+		data.Repository.LatestCommitSHA,
+	}
+	if err := writer.Write(record); err != nil {
+		return fmt.Errorf("failed to write CSV record: %w", err)
+	}
+
+	return nil
+}

--- a/internal/export/export_test.go
+++ b/internal/export/export_test.go
@@ -1,0 +1,232 @@
+package export
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"mona-actions/gh-migration-validator/internal/api"
+	"mona-actions/gh-migration-validator/internal/validator"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// createTestExportData creates sample export data for testing
+func createTestExportData() ExportData {
+	return ExportData{
+		ExportTimestamp: time.Date(2025, 10, 2, 14, 30, 0, 0, time.UTC),
+		Repository: validator.RepositoryData{
+			Owner:           "test-owner",
+			Name:            "test-repo",
+			Issues:          42,
+			PRs:             &api.PRCounts{Open: 5, Closed: 10, Merged: 15, Total: 30},
+			Tags:            8,
+			Releases:        3,
+			CommitCount:     150,
+			LatestCommitSHA: "abc123def456",
+		},
+	}
+}
+
+// Note: Full integration tests for ExportSourceData would require API mocking
+// The following tests focus on the individual components that can be tested in isolation
+
+func TestGenerateExportFileName(t *testing.T) {
+	testCases := []struct {
+		owner     string
+		repo      string
+		format    string
+		timestamp time.Time
+		expected  string
+	}{
+		{
+			owner:     "myorg",
+			repo:      "myrepo",
+			format:    "json",
+			timestamp: time.Date(2025, 10, 2, 14, 30, 45, 0, time.UTC),
+			expected:  "myorg_myrepo_export_20251002_143045.json",
+		},
+		{
+			owner:     "github",
+			repo:      "docs",
+			format:    "csv",
+			timestamp: time.Date(2025, 12, 25, 9, 15, 30, 0, time.UTC),
+			expected:  "github_docs_export_20251225_091530.csv",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.expected, func(t *testing.T) {
+			result := generateExportFileName(tc.owner, tc.repo, tc.format, tc.timestamp)
+			if result != tc.expected {
+				t.Errorf("Expected %s, got %s", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestExportToJSON(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+	filename := filepath.Join(tmpDir, "test.json")
+
+	// Create test data
+	exportData := ExportData{
+		ExportTimestamp: time.Date(2025, 10, 2, 14, 30, 0, 0, time.UTC),
+		Repository: validator.RepositoryData{
+			Owner:           "test-owner",
+			Name:            "test-repo",
+			Issues:          10,
+			PRs:             &api.PRCounts{Open: 1, Closed: 2, Merged: 3, Total: 6},
+			Tags:            5,
+			Releases:        2,
+			CommitCount:     100,
+			LatestCommitSHA: "abcd1234",
+		},
+	}
+
+	// Test the function
+	err := exportToJSON(exportData, filename)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	// Verify file exists and content is valid JSON
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatalf("Failed to read file: %v", err)
+	}
+
+	var parsed ExportData
+	if err := json.Unmarshal(content, &parsed); err != nil {
+		t.Fatalf("Failed to parse JSON: %v", err)
+	}
+
+	// Verify data integrity
+	if parsed.Repository.Owner != exportData.Repository.Owner {
+		t.Errorf("Expected owner %s, got %s", exportData.Repository.Owner, parsed.Repository.Owner)
+	}
+}
+
+func TestExportToCSV(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+	filename := filepath.Join(tmpDir, "test.csv")
+
+	// Create test data
+	exportData := ExportData{
+		ExportTimestamp: time.Date(2025, 10, 2, 14, 30, 0, 0, time.UTC),
+		Repository: validator.RepositoryData{
+			Owner:           "test-owner",
+			Name:            "test-repo",
+			Issues:          10,
+			PRs:             &api.PRCounts{Open: 1, Closed: 2, Merged: 3, Total: 6},
+			Tags:            5,
+			Releases:        2,
+			CommitCount:     100,
+			LatestCommitSHA: "abcd1234",
+		},
+	}
+
+	// Test the function
+	err := exportToCSV(exportData, filename)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	// Verify file exists and content is valid CSV
+	file, err := os.Open(filename)
+	if err != nil {
+		t.Fatalf("Failed to open file: %v", err)
+	}
+	defer file.Close()
+
+	reader := csv.NewReader(file)
+	records, err := reader.ReadAll()
+	if err != nil {
+		t.Fatalf("Failed to read CSV: %v", err)
+	}
+
+	// Should have header + 1 data row
+	if len(records) != 2 {
+		t.Fatalf("Expected 2 rows, got %d", len(records))
+	}
+
+	// Verify some key data points
+	dataRow := records[1]
+	if dataRow[1] != "test-owner" {
+		t.Errorf("Expected owner test-owner, got %s", dataRow[1])
+	}
+	if dataRow[2] != "test-repo" {
+		t.Errorf("Expected repo test-repo, got %s", dataRow[2])
+	}
+	if dataRow[3] != "10" {
+		t.Errorf("Expected 10 issues, got %s", dataRow[3])
+	}
+}
+
+func TestExportToJSON_CreateDirectory(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+
+	// Use a nested path that doesn't exist
+	filename := filepath.Join(tmpDir, "nested", "dir", "test.json")
+
+	exportData := ExportData{
+		ExportTimestamp: time.Now(),
+		Repository: validator.RepositoryData{
+			Owner:           "test",
+			Name:            "repo",
+			Issues:          5,
+			PRs:             &api.PRCounts{Open: 1, Closed: 2, Merged: 3, Total: 6},
+			Tags:            2,
+			Releases:        1,
+			CommitCount:     50,
+			LatestCommitSHA: "test123",
+		},
+	}
+
+	// Test the function
+	err := exportToJSON(exportData, filename)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	// Verify file was created in the nested directory
+	if _, err := os.Stat(filename); os.IsNotExist(err) {
+		t.Fatalf("Expected file to be created at %s", filename)
+	}
+}
+
+func TestExportToCSV_CreateDirectory(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+
+	// Use a nested path that doesn't exist
+	filename := filepath.Join(tmpDir, "nested", "dir", "test.csv")
+
+	exportData := ExportData{
+		ExportTimestamp: time.Now(),
+		Repository: validator.RepositoryData{
+			Owner:           "test",
+			Name:            "repo",
+			Issues:          5,
+			PRs:             &api.PRCounts{Open: 1, Closed: 2, Merged: 3, Total: 6},
+			Tags:            2,
+			Releases:        1,
+			CommitCount:     50,
+			LatestCommitSHA: "test123",
+		},
+	}
+
+	// Test the function
+	err := exportToCSV(exportData, filename)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	// Verify file was created in the nested directory
+	if _, err := os.Stat(filename); os.IsNotExist(err) {
+		t.Fatalf("Expected file to be created at %s", filename)
+	}
+}

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -170,6 +170,11 @@ func (mv *MigrationValidator) retrieveSource(owner, name string, spinner *pterm.
 	return nil
 }
 
+// RetrieveSourceData is a public wrapper for retrieveSource for use by the export package
+func (mv *MigrationValidator) RetrieveSourceData(owner, name string, spinner *pterm.SpinnerPrinter) error {
+	return mv.retrieveSource(owner, name, spinner)
+}
+
 // retrieveTarget retrieves all repository data from the target repository
 func (mv *MigrationValidator) retrieveTarget(owner, name string, spinner *pterm.SpinnerPrinter) error {
 	startTime := time.Now()


### PR DESCRIPTION
<!--
## Release Drafter

This repository uses [Release Drafter](https://github.com/release-drafter/release-drafter) for versioning. Please add one of the following labels to your pull request to indicate the type of change:

- `major` label will be a major version
- `minor` or `enhancement` will bump it to a minor version
- `patch` or `bug` will bump it to a patch version (this is the default if no label is applied)
-->

## Description

This pull request introduces a new export feature to the repository, allowing users to export source repository metadata at a specific point in time, in either JSON or CSV format. The implementation includes a new CLI command, supporting code in the export package, and comprehensive unit tests for the export logic.

## Checklist

<!-- - [ ] Issue linked if existing -->
- [x] I have added the appropriate label to this PR according to the type of change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests

## Additional Context

**New export command and functionality:**

* Added the `export` subcommand to the CLI (`cmd/export.go`), enabling users to export repository data such as issues, pull requests, tags, releases, commits, and the latest commit SHA, with support for JSON and CSV formats.
* Implemented the `internal/export/export.go` package, which handles data retrieval (via the validator), formats the export, and writes output files, including automatic directory creation and default file naming.
* Exposed a public `RetrieveSourceData` method in the validator for use by the export package, wrapping the internal data retrieval logic.

**Testing and reliability improvements:**

* Added unit tests for the export logic in `internal/export/export_test.go`, covering filename generation, JSON and CSV export, and directory creation for output files.