### PR TITLE
add option to exit 2 if validation fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,24 @@ export GHMV_TARGET_REPO="my-repo"
 export GHMV_MARKDOWN_TABLE="true"
 export GHMV_MARKDOWN_FILE="validation-report.md"
 export GHMV_NO_LFS="true"  # Optional: skip LFS validation
+export GHMV_STRICT_EXIT="true"  # Optional: exit with status 2 when validations fail
 
 gh migration-validator
+```
+
+### Strict Exit Mode
+
+Use strict exit mode when you need shell pipelines to detect validation failures. Enable it with the `--strict-exit` flag or set `GHMV_STRICT_EXIT=true` to return exit code 2 whenever any validation fails. Without this option the command exits 0 while still reporting failures in the output.
+
+```bash
+gh migration-validator \
+  --github-source-org "source-org" \
+  --github-target-org "target-org" \
+  --source-repo "my-repo" \
+  --target-repo "my-repo" \
+  --github-source-pat "ghp_xxx" \
+  --github-target-pat "ghp_yyy" \
+  --strict-exit
 ```
 
 ### GitHub App Authentication

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,6 +52,10 @@ between source and target organizations.`,
 
 		// Print the validation results - always report what we found
 		migrationValidator.PrintValidationResults(results)
+
+		if viper.GetBool("STRICT_EXIT") && validator.HasFailures(results) {
+			os.Exit(2)
+		}
 	},
 }
 
@@ -77,6 +81,7 @@ func init() {
 	rootCmd.Flags().BoolP("markdown-table", "m", false, "Print results as a markdown table")
 	rootCmd.Flags().String("markdown-file", "", "Write markdown output to the specified file (optional)")
 	rootCmd.Flags().Bool("no-lfs", false, "Skip LFS object validation")
+	rootCmd.PersistentFlags().Bool("strict-exit", false, "Exit with status 2 when validations fail")
 
 	// Set environment variable prefix: GHMV (GitHub Migration Validator)
 	viper.SetEnvPrefix("GHMV")
@@ -94,6 +99,7 @@ func init() {
 	viper.BindPFlag("MARKDOWN_TABLE", rootCmd.Flags().Lookup("markdown-table"))
 	viper.BindPFlag("MARKDOWN_FILE", rootCmd.Flags().Lookup("markdown-file"))
 	viper.BindPFlag("NO_LFS", rootCmd.Flags().Lookup("no-lfs"))
+	viper.BindPFlag("STRICT_EXIT", rootCmd.PersistentFlags().Lookup("strict-exit"))
 
 	// Bind environment variables explicitly for additional app authentication options
 	viper.BindEnv("SOURCE_PRIVATE_KEY")
@@ -103,6 +109,7 @@ func init() {
 	viper.BindEnv("TARGET_APP_ID")
 	viper.BindEnv("TARGET_INSTALLATION_ID")
 	viper.BindEnv("MARKDOWN_FILE")
+	viper.BindEnv("STRICT_EXIT")
 }
 
 // requiredConfig defines a required configuration with its flag and env var names

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -25,6 +25,7 @@ func resetViperAndEnv() {
 		"GHMV_SOURCE_HOSTNAME",
 		"GHMV_MARKDOWN_TABLE",
 		"GHMV_MARKDOWN_FILE",
+		"GHMV_STRICT_EXIT",
 	}
 	for _, env := range envVars {
 		os.Unsetenv(env)
@@ -45,6 +46,7 @@ func setupViperWithFlags(cmd *cobra.Command) {
 	viper.BindPFlag("TARGET_REPO", cmd.Flags().Lookup("target-repo"))
 	viper.BindPFlag("MARKDOWN_TABLE", cmd.Flags().Lookup("markdown-table"))
 	viper.BindPFlag("MARKDOWN_FILE", cmd.Flags().Lookup("markdown-file"))
+	viper.BindPFlag("STRICT_EXIT", cmd.Flags().Lookup("strict-exit"))
 }
 
 // createTestCommand creates a fresh command with all flags for testing
@@ -65,6 +67,7 @@ func createTestCommand() *cobra.Command {
 	cmd.Flags().StringP("target-repo", "", "", "Target repo")
 	cmd.Flags().BoolP("markdown-table", "m", false, "Markdown table")
 	cmd.Flags().String("markdown-file", "", "Markdown output file")
+	cmd.Flags().Bool("strict-exit", false, "Strict exit")
 
 	return cmd
 }

--- a/cmd/validate_from_export.go
+++ b/cmd/validate_from_export.go
@@ -120,6 +120,10 @@ The validation compares the same metrics as the standard validate command:
 
 		// Display results using existing method
 		migrationValidator.PrintValidationResults(results)
+
+		if viper.GetBool("STRICT_EXIT") && validator.HasFailures(results) {
+			os.Exit(2)
+		}
 	},
 }
 

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -76,6 +76,17 @@ type ValidationResult struct {
 	Difference int              // How many items are missing in target (negative if target has more)
 }
 
+// HasFailures reports whether any validation result failed so callers can set exit codes accurately.
+func HasFailures(results []ValidationResult) bool {
+	for _, result := range results {
+		if result.StatusType == ValidationStatusFail {
+			return true
+		}
+	}
+
+	return false
+}
+
 // MigrationValidator handles the validation of GitHub organization migrations
 type MigrationValidator struct {
 	api        *api.GitHubAPI

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -520,6 +520,26 @@ func TestValidationResult_CommitSHAComparison(t *testing.T) {
 	}
 }
 
+func TestHasFailures(t *testing.T) {
+	t.Run("returns true when failures present", func(t *testing.T) {
+		results := []ValidationResult{
+			{StatusType: ValidationStatusPass},
+			{StatusType: ValidationStatusFail},
+		}
+
+		assert.True(t, HasFailures(results))
+	})
+
+	t.Run("returns false when no failures present", func(t *testing.T) {
+		results := []ValidationResult{
+			{StatusType: ValidationStatusPass},
+			{StatusType: ValidationStatusWarn},
+		}
+
+		assert.False(t, HasFailures(results))
+	})
+}
+
 func TestValidateRepositoryData_MetricNames(t *testing.T) {
 	// Test that validateRepositoryData returns exactly the expected metrics with correct names
 	validator := setupTestValidator(


### PR DESCRIPTION
## Description

This pull request adds a "strict exit mode" to the GitHub Migration Validator, allowing the CLI to exit with a non-zero status (2) if any validation failures are detected. This feature is configurable via a new `--strict-exit` flag or the `GHMV_STRICT_EXIT` environment variable, making it easier to use the tool in automated scripts and CI/CD pipelines. The documentation and test coverage have also been updated accordingly.

## Checklist

<!-- - [ ] Issue linked if existing -->
- [x] I have added the appropriate label to this PR according to the type of change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests

## Additional Context

