### PR TITLE
count all webhooks active or inactive

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -591,7 +591,7 @@ func (api *GitHubAPI) GetBranchProtectionRulesCount(clientType ClientType, owner
 	return query.Repository.BranchProtectionRules.TotalCount, nil
 }
 
-// GetWebhookCount retrieves the count of active webhooks for a repository using REST API
+// GetWebhookCount retrieves the count of all webhooks (active and inactive) for a repository using REST API
 func (api *GitHubAPI) GetWebhookCount(clientType ClientType, owner, name string) (int, error) {
 	ctx := context.Background()
 
@@ -602,7 +602,7 @@ func (api *GitHubAPI) GetWebhookCount(clientType ClientType, owner, name string)
 
 	// List all webhooks for the repository
 	opts := &github.ListOptions{PerPage: 100}
-	var activeWebhookCount int
+	var webhookCount int
 
 	for {
 		webhooks, resp, err := client.Repositories.ListHooks(ctx, owner, name, opts)
@@ -610,12 +610,8 @@ func (api *GitHubAPI) GetWebhookCount(clientType ClientType, owner, name string)
 			return 0, fmt.Errorf("failed to query %s repository webhook count: %v", clientName, err)
 		}
 
-		// Count only active webhooks
-		for _, webhook := range webhooks {
-			if webhook.Active != nil && *webhook.Active {
-				activeWebhookCount++
-			}
-		}
+		// Count all webhooks (both active and inactive)
+		webhookCount += len(webhooks)
 
 		if resp.NextPage == 0 {
 			break
@@ -623,7 +619,7 @@ func (api *GitHubAPI) GetWebhookCount(clientType ClientType, owner, name string)
 		opts.Page = resp.NextPage
 	}
 
-	return activeWebhookCount, nil
+	return webhookCount, nil
 }
 
 // ListOrganizationMigrations retrieves the list of organization migrations using REST API

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1205,7 +1205,7 @@ func TestGitHubAPI_GetWebhookCount(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name:       "mixed active and inactive webhooks - only counts active",
+			name:       "mixed active and inactive webhooks - counts all",
 			clientType: SourceClient,
 			owner:      "testowner",
 			repo:       "testrepo",
@@ -1241,7 +1241,7 @@ func TestGitHubAPI_GetWebhookCount(t *testing.T) {
 					}
 				}
 			]`,
-			expectedCount: 2,
+			expectedCount: 3,
 			expectedError: false,
 		},
 	}


### PR DESCRIPTION
## Description
This pull request updates the logic for counting webhooks in a repository. Previously, only active webhooks were counted; now, the count includes both active and inactive webhooks. The associated test cases and documentation have been updated to reflect this change.

Fixes #21 

## Checklist

<!-- - [ ] Issue linked if existing -->
- [x] I have added the appropriate label to this PR according to the type of change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests

## Additional Context

None