### PR TITLE
Add validate-org command for org-level migration validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,77 @@ gh migration-validator validate-from-export --export-file "path/to/export.json"
 
 This ensures you're validating against the exact state of the source repository when the migration occurred, regardless of any subsequent changes.
 
+## Validate Organization
+
+The `validate-org` command validates **all repositories** in a source organization against a target organization in a single run, producing one consolidated report instead of running validation per repository.
+
+### Validate-Org Usage
+
+```bash
+gh migration-validator validate-org \
+  --github-source-org "source-org" \
+  --github-target-org "target-org" \
+  --github-source-pat "ghp_xxx" \
+  --github-target-pat "ghp_yyy"
+```
+
+### With Markdown Report
+
+```bash
+gh migration-validator validate-org \
+  --github-source-org "source-org" \
+  --github-target-org "target-org" \
+  --github-source-pat "ghp_xxx" \
+  --github-target-pat "ghp_yyy" \
+  --markdown-table \
+  --markdown-file "org-validation-report.md"
+```
+
+### Environment Variables for Validate-Org
+
+```bash
+export GHMV_SOURCE_ORGANIZATION="source-org"
+export GHMV_SOURCE_TOKEN="ghp_xxx"
+export GHMV_TARGET_ORGANIZATION="target-org"
+export GHMV_TARGET_TOKEN="ghp_yyy"
+
+gh migration-validator validate-org
+```
+
+### Validate-Org Options
+
+#### Source Flags
+
+- `--github-source-org` / `-s` (required): Source GitHub organization
+- `--github-source-pat` / `-a` (required): Source GitHub token with read permissions
+- `--source-hostname` / `-u` (optional): GitHub Enterprise Server URL for source
+
+#### Shared Target Flags (inherited from root)
+
+- `--github-target-org` / `-t` (required): Target GitHub organization
+- `--github-target-pat` / `-b` (required): Target GitHub token with read permissions
+- `--target-hostname` / `-v` (optional): GitHub Enterprise Server URL for target
+- `--markdown-table` / `-m`: Output results in markdown format
+- `--markdown-file`: Write consolidated markdown report to a file
+- `--no-lfs`: Skip LFS object validation
+- `--strict-exit`: Exit with status 2 on validation failures
+
+### How It Works
+
+1. Lists all repositories in the source organization
+2. For each repository, validates it against the same-named repository in the target organization
+3. Repositories that fail or cannot be accessed are recorded with an error but do not stop validation of remaining repositories
+4. Produces a **single summary table** with per-repository pass/fail/warn status
+5. Optionally writes one consolidated markdown report with details for every repository
+
+### Output
+
+The consolidated report includes:
+
+- A summary table with each repository's overall status (pass/fail/warn)
+- Total counts across all repositories
+- Per-repository detailed validation results (in the markdown report)
+
 ## Bitbucket Validation
 
 The `bitbucket` subcommand validates migrations from Bitbucket (Server / Data Center) to GitHub by comparing API metrics between the source Bitbucket instance and the target GitHub repository. This is useful for verifying that repository data was migrated correctly when moving from Bitbucket to GitHub.

--- a/README.md
+++ b/README.md
@@ -309,7 +309,11 @@ This ensures you're validating against the exact state of the source repository 
 
 ## Validate Organization
 
-The `validate-org` command validates **all repositories** in a source organization against a target organization in a single run, producing one consolidated report instead of running validation per repository.
+The `validate-org` command validates repositories migrated from a source organization to a target organization in a single run, producing one consolidated report.
+
+By default it lists all repositories in the source org and validates each one against the same-named repo in the target org. This works well for **org-by-org migrations** (e.g. using GEI) where repository names are preserved and all repos (including forks and archives) are migrated. Forked repos have issue validation skipped automatically since forks have issues disabled.
+
+When source and target repository names differ, or you only want to validate a subset, provide a CSV mapping file via `--repo-list`.
 
 ### Validate-Org Usage
 
@@ -320,6 +324,29 @@ gh migration-validator validate-org \
   --github-source-pat "ghp_xxx" \
   --github-target-pat "ghp_yyy"
 ```
+
+### With Repository Mapping (CSV)
+
+When not all source repos exist in the target, or names differ:
+
+```csv
+# repos.csv
+source_repo,target_repo
+my-app,my-app-migrated
+shared-lib,shared-lib
+internal-tools,internal-tools
+```
+
+```bash
+gh migration-validator validate-org \
+  --github-source-org "source-org" \
+  --github-target-org "target-org" \
+  --github-source-pat "ghp_xxx" \
+  --github-target-pat "ghp_yyy" \
+  --repo-list repos.csv
+```
+
+If a CSV line has only one column, the target name is assumed to match the source. Lines starting with `#` are comments. A header row containing both "source" and "target" is automatically skipped.
 
 ### With Markdown Report
 
@@ -332,6 +359,8 @@ gh migration-validator validate-org \
   --markdown-table \
   --markdown-file "org-validation-report.md"
 ```
+
+When `--markdown-file` is specified, results are written incrementally after each repository completes, so partial progress survives interruptions (e.g. Ctrl+C).
 
 ### Environment Variables for Validate-Org
 
@@ -352,6 +381,10 @@ gh migration-validator validate-org
 - `--github-source-pat` / `-a` (required): Source GitHub token with read permissions
 - `--source-hostname` / `-u` (optional): GitHub Enterprise Server URL for source
 
+#### Repository Selection
+
+- `--repo-list` (optional): Path to CSV file with `source_repo,target_repo` mappings. When omitted, all repos from the source org are validated with matching names.
+
 #### Shared Target Flags (inherited from root)
 
 - `--github-target-org` / `-t` (required): Target GitHub organization
@@ -364,17 +397,17 @@ gh migration-validator validate-org
 
 ### How It Works
 
-1. Lists all repositories in the source organization
-2. For each repository, validates it against the same-named repository in the target organization
-3. Repositories that fail or cannot be accessed are recorded with an error but do not stop validation of remaining repositories
-4. Produces a **single summary table** with per-repository pass/fail/warn status
-5. Optionally writes one consolidated markdown report with details for every repository
+1. Determines repositories to validate, either from `--repo-list` CSV or by listing all repos in the source org
+2. For each repo pair, validates source against target (names can differ when using CSV mapping)
+3. Repos that fail or cannot be accessed are recorded with an error but do not stop validation of remaining repos
+4. When `--markdown-file` is set, the report is updated after each repo (incremental writes)
+5. Produces a **single summary table** with per-repository pass/fail/warn/info status
 
 ### Output
 
 The consolidated report includes:
 
-- A summary table with each repository's overall status (pass/fail/warn)
+- A summary table with each repository's overall status (pass/fail/warn/info)
 - Total counts across all repositories
 - Per-repository detailed validation results (in the markdown report)
 

--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ gh migration-validator validate-org \
   --repo-list repos.csv
 ```
 
-If a CSV line has only one column, the target name is assumed to match the source. Lines starting with `#` are comments. A header row containing both "source" and "target" is automatically skipped.
+If a CSV line has only one column, the target name is assumed to match the source. Lines starting with `#` are comments. A header row of `source_repo,target_repo` or `source,target` is automatically skipped.
 
 ### With Markdown Report
 

--- a/cmd/validate_org.go
+++ b/cmd/validate_org.go
@@ -20,13 +20,26 @@ import (
 var validateOrgCmd = &cobra.Command{
 	Use:   "validate-org",
 	Short: "Validate all repositories in an organization migration",
-	Long: `Validate all repositories migrated from a source GitHub organization to a target
+	Long: `Validate repositories migrated from a source GitHub organization to a target
 GitHub organization in a single run, producing one consolidated report.
 
+By default, the command lists all repositories in the source organization and
+validates each one against the same-named repository in the target organization.
+This includes forks and archived repos, since GEI migrates them too.
+
+To validate a specific subset of repositories, or when source and target
+repository names differ, provide a CSV file via --repo-list:
+
+  source_repo,target_repo
+  my-app,my-app-migrated
+  shared-lib,shared-lib
+
+If a line has only one column, the target name is assumed to match the source.
+Lines starting with # are comments.
+
 This command:
-- Lists all repositories in the source organization
-- Validates each repository against the matching target repository
-- Produces a single summary table with per-repo pass/fail/warn status
+- Validates each repository pair and produces a consolidated summary table
+- Writes results incrementally so partial progress survives interruptions
 - Optionally writes a consolidated markdown report to a file
 
 Repositories that cannot be accessed or fail validation are recorded with an
@@ -40,6 +53,7 @@ error but do not stop validation of the remaining repositories.`,
 
 		sourceOrganization := viper.GetString("SOURCE_ORGANIZATION")
 		targetOrganization := viper.GetString("TARGET_ORGANIZATION")
+		repoListFile, _ := cmd.Flags().GetString("repo-list")
 
 		// Initialize API with both source and target clients
 		ghAPI, err := api.NewGitHubAPI()
@@ -48,28 +62,54 @@ error but do not stop validation of the remaining repositories.`,
 			os.Exit(1)
 		}
 
-		// List repositories from the source organization
-		spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Listing repositories in %s...", sourceOrganization))
-		repos, err := ghAPI.ListOrgRepos(api.SourceClient, sourceOrganization)
-		if err != nil {
-			spinner.Fail(fmt.Sprintf("Failed to list repositories: %v", err))
-			os.Exit(1)
-		}
-		spinner.Success(fmt.Sprintf("Found %d repositories in %s", len(repos), sourceOrganization))
+		var mappings []validator.RepoMapping
 
-		if len(repos) == 0 {
-			pterm.Warning.Println("No repositories found in source organization")
+		if repoListFile != "" {
+			// Load explicit repo mappings from CSV
+			mappings, err = validator.ParseRepoListCSV(repoListFile)
+			if err != nil {
+				fmt.Printf("Failed to parse repo list: %v\n", err)
+				os.Exit(1)
+			}
+			pterm.Success.Printf("Loaded %d repository mappings from %s\n", len(mappings), repoListFile)
+		} else {
+			// List all repositories from the source organization
+			spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Listing repositories in %s...", sourceOrganization))
+			repos, err := ghAPI.ListOrgRepos(api.SourceClient, sourceOrganization)
+			if err != nil {
+				spinner.Fail(fmt.Sprintf("Failed to list repositories: %v", err))
+				os.Exit(1)
+			}
+			spinner.Success(fmt.Sprintf("Found %d repositories in %s", len(repos), sourceOrganization))
+
+			// Default mapping: same name source → target, preserving fork info
+			for _, repo := range repos {
+				mappings = append(mappings, validator.RepoMapping{SourceRepo: repo.Name, TargetRepo: repo.Name, IsFork: repo.IsFork})
+			}
+		}
+
+		if len(mappings) == 0 {
+			pterm.Warning.Println("No repositories to validate")
 			return
+		}
+
+		// Set up incremental markdown writing callback
+		markdownFile := viper.GetString("MARKDOWN_FILE")
+		var onResult func(*validator.OrgValidationSummary)
+		if markdownFile != "" {
+			onResult = func(summary *validator.OrgValidationSummary) {
+				writeOrgMarkdownFile(summary, markdownFile)
+			}
 		}
 
 		// Run org-level validation
 		migrationValidator := validator.New(ghAPI)
-		summary := migrationValidator.ValidateOrganization(sourceOrganization, targetOrganization, repos)
+		summary := migrationValidator.ValidateOrganization(sourceOrganization, targetOrganization, mappings, onResult)
 
 		// Print consolidated results
 		validator.PrintOrgValidationResults(summary)
 
-		// Handle markdown output
+		// Handle markdown output (final write)
 		outputOrgMarkdown(summary)
 
 		if viper.GetBool("STRICT_EXIT") && validator.OrgHasFailures(summary) {
@@ -83,6 +123,7 @@ func init() {
 	validateOrgCmd.Flags().StringP("github-source-org", "s", "", "Source GitHub organization")
 	validateOrgCmd.Flags().StringP("github-source-pat", "a", "", "Source Organization GitHub token")
 	validateOrgCmd.Flags().StringP("source-hostname", "u", "", "GitHub Enterprise source hostname url (optional)")
+	validateOrgCmd.Flags().String("repo-list", "", "Path to CSV file with source,target repository mappings")
 
 	// Bind to Viper in PreRun so they override env vars at execution time
 	validateOrgCmd.PreRun = func(cmd *cobra.Command, args []string) {
@@ -124,10 +165,12 @@ func outputOrgMarkdown(summary *validator.OrgValidationSummary) {
 		pterm.Info.Println("💡 Tip: You can select and copy the entire markdown section above to paste into documentation, issues, or pull requests!")
 	}
 
-	if markdownFile == "" {
-		return
+	if markdownFile != "" {
+		writeOrgMarkdownFile(summary, markdownFile)
 	}
+}
 
+func writeOrgMarkdownFile(summary *validator.OrgValidationSummary, markdownFile string) {
 	if dir := filepath.Dir(markdownFile); dir != "." {
 		if _, err := os.Stat(dir); os.IsNotExist(err) {
 			pterm.Error.Printf("Directory %q does not exist for markdown file\n", dir)
@@ -141,6 +184,4 @@ func outputOrgMarkdown(summary *validator.OrgValidationSummary) {
 		pterm.Error.Printf("Failed to write markdown file %s: %v\n", markdownFile, err)
 		return
 	}
-
-	pterm.Success.Printf("📁 Markdown report saved to %s\n", markdownFile)
 }

--- a/cmd/validate_org.go
+++ b/cmd/validate_org.go
@@ -84,7 +84,8 @@ error but do not stop validation of the remaining repositories.`,
 
 			// Default mapping: same name source → target, preserving fork info
 			for _, repo := range repos {
-				mappings = append(mappings, validator.RepoMapping{SourceRepo: repo.Name, TargetRepo: repo.Name, IsFork: repo.IsFork})
+				isFork := repo.IsFork
+				mappings = append(mappings, validator.RepoMapping{SourceRepo: repo.Name, TargetRepo: repo.Name, IsFork: &isFork})
 			}
 		}
 

--- a/cmd/validate_org.go
+++ b/cmd/validate_org.go
@@ -1,0 +1,146 @@
+/*
+Copyright © 2025 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"mona-actions/gh-migration-validator/internal/api"
+	"mona-actions/gh-migration-validator/internal/validator"
+	"os"
+	"path/filepath"
+
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// validateOrgCmd represents the validate-org command
+var validateOrgCmd = &cobra.Command{
+	Use:   "validate-org",
+	Short: "Validate all repositories in an organization migration",
+	Long: `Validate all repositories migrated from a source GitHub organization to a target
+GitHub organization in a single run, producing one consolidated report.
+
+This command:
+- Lists all repositories in the source organization
+- Validates each repository against the matching target repository
+- Produces a single summary table with per-repo pass/fail/warn status
+- Optionally writes a consolidated markdown report to a file
+
+Repositories that cannot be accessed or fail validation are recorded with an
+error but do not stop validation of the remaining repositories.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// Validate required variables
+		if err := checkOrgVars(); err != nil {
+			fmt.Printf("Organization validation configuration failed: %v\n", err)
+			os.Exit(1)
+		}
+
+		sourceOrganization := viper.GetString("SOURCE_ORGANIZATION")
+		targetOrganization := viper.GetString("TARGET_ORGANIZATION")
+
+		// Initialize API with both source and target clients
+		ghAPI, err := api.NewGitHubAPI()
+		if err != nil {
+			fmt.Printf("Failed to initialize API clients: %v\n", err)
+			os.Exit(1)
+		}
+
+		// List repositories from the source organization
+		spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Listing repositories in %s...", sourceOrganization))
+		repos, err := ghAPI.ListOrgRepos(api.SourceClient, sourceOrganization)
+		if err != nil {
+			spinner.Fail(fmt.Sprintf("Failed to list repositories: %v", err))
+			os.Exit(1)
+		}
+		spinner.Success(fmt.Sprintf("Found %d repositories in %s", len(repos), sourceOrganization))
+
+		if len(repos) == 0 {
+			pterm.Warning.Println("No repositories found in source organization")
+			return
+		}
+
+		// Run org-level validation
+		migrationValidator := validator.New(ghAPI)
+		summary := migrationValidator.ValidateOrganization(sourceOrganization, targetOrganization, repos)
+
+		// Print consolidated results
+		validator.PrintOrgValidationResults(summary)
+
+		// Handle markdown output
+		outputOrgMarkdown(summary)
+
+		if viper.GetBool("STRICT_EXIT") && validator.OrgHasFailures(summary) {
+			os.Exit(2)
+		}
+	},
+}
+
+func init() {
+	// Source flags (local to this command)
+	validateOrgCmd.Flags().StringP("github-source-org", "s", "", "Source GitHub organization")
+	validateOrgCmd.Flags().StringP("github-source-pat", "a", "", "Source Organization GitHub token")
+	validateOrgCmd.Flags().StringP("source-hostname", "u", "", "GitHub Enterprise source hostname url (optional)")
+
+	// Bind to Viper in PreRun so they override env vars at execution time
+	validateOrgCmd.PreRun = func(cmd *cobra.Command, args []string) {
+		viper.BindPFlag("SOURCE_ORGANIZATION", cmd.Flags().Lookup("github-source-org"))
+		viper.BindPFlag("SOURCE_TOKEN", cmd.Flags().Lookup("github-source-pat"))
+		viper.BindPFlag("SOURCE_HOSTNAME", cmd.Flags().Lookup("source-hostname"))
+	}
+
+	rootCmd.AddCommand(validateOrgCmd)
+}
+
+func checkOrgVars() error {
+	required := map[string]requiredConfig{
+		"SOURCE_ORGANIZATION": {"--github-source-org / -s", "GHMV_SOURCE_ORGANIZATION"},
+		"TARGET_ORGANIZATION": {"--github-target-org / -t", "GHMV_TARGET_ORGANIZATION"},
+		"SOURCE_TOKEN":        {"--github-source-pat / -a", "GHMV_SOURCE_TOKEN"},
+		"TARGET_TOKEN":        {"--github-target-pat / -b", "GHMV_TARGET_TOKEN"},
+	}
+
+	for key, info := range required {
+		if viper.GetString(key) == "" {
+			return fmt.Errorf("%s is required. Set via %s flag or %s environment variable",
+				key, info.flag, info.envVar)
+		}
+	}
+
+	return nil
+}
+
+func outputOrgMarkdown(summary *validator.OrgValidationSummary) {
+	markdownTable := viper.GetBool("MARKDOWN_TABLE")
+	markdownFile := viper.GetString("MARKDOWN_FILE")
+
+	if markdownTable {
+		pterm.DefaultSection.Println("📋 Markdown Table (Copy-Paste Ready)")
+		fmt.Println("```markdown")
+		validator.WriteOrgMarkdownReport(summary, os.Stdout)
+		fmt.Println("```")
+		pterm.Info.Println("💡 Tip: You can select and copy the entire markdown section above to paste into documentation, issues, or pull requests!")
+	}
+
+	if markdownFile == "" {
+		return
+	}
+
+	if dir := filepath.Dir(markdownFile); dir != "." {
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			pterm.Error.Printf("Directory %q does not exist for markdown file\n", dir)
+			return
+		}
+	}
+
+	var buf bytes.Buffer
+	validator.WriteOrgMarkdownReport(summary, &buf)
+	if err := os.WriteFile(markdownFile, buf.Bytes(), 0o644); err != nil {
+		pterm.Error.Printf("Failed to write markdown file %s: %v\n", markdownFile, err)
+		return
+	}
+
+	pterm.Success.Printf("📁 Markdown report saved to %s\n", markdownFile)
+}

--- a/cmd/validate_org_test.go
+++ b/cmd/validate_org_test.go
@@ -1,0 +1,140 @@
+package cmd
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestCheckOrgVars_AllProvided(t *testing.T) {
+	resetViperAndEnv()
+	defer resetViperAndEnv()
+
+	os.Setenv("GHMV_SOURCE_ORGANIZATION", "source-org")
+	os.Setenv("GHMV_TARGET_ORGANIZATION", "target-org")
+	os.Setenv("GHMV_SOURCE_TOKEN", "source-token")
+	os.Setenv("GHMV_TARGET_TOKEN", "target-token")
+
+	viper.SetEnvPrefix("GHMV")
+	viper.AutomaticEnv()
+
+	err := checkOrgVars()
+	if err != nil {
+		t.Errorf("Expected no error when all vars are provided, got: %v", err)
+	}
+}
+
+func TestCheckOrgVars_MissingSourceOrg(t *testing.T) {
+	resetViperAndEnv()
+	defer resetViperAndEnv()
+
+	os.Setenv("GHMV_TARGET_ORGANIZATION", "target-org")
+	os.Setenv("GHMV_SOURCE_TOKEN", "token")
+	os.Setenv("GHMV_TARGET_TOKEN", "token")
+
+	viper.SetEnvPrefix("GHMV")
+	viper.AutomaticEnv()
+
+	err := checkOrgVars()
+	if err == nil {
+		t.Error("Expected error when SOURCE_ORGANIZATION is missing")
+	}
+	if !strings.Contains(err.Error(), "SOURCE_ORGANIZATION") {
+		t.Errorf("Error should mention SOURCE_ORGANIZATION, got: %v", err)
+	}
+}
+
+func TestCheckOrgVars_MissingTargetOrg(t *testing.T) {
+	resetViperAndEnv()
+	defer resetViperAndEnv()
+
+	os.Setenv("GHMV_SOURCE_ORGANIZATION", "source-org")
+	os.Setenv("GHMV_SOURCE_TOKEN", "token")
+	os.Setenv("GHMV_TARGET_TOKEN", "token")
+
+	viper.SetEnvPrefix("GHMV")
+	viper.AutomaticEnv()
+
+	err := checkOrgVars()
+	if err == nil {
+		t.Error("Expected error when TARGET_ORGANIZATION is missing")
+	}
+	if !strings.Contains(err.Error(), "TARGET_ORGANIZATION") {
+		t.Errorf("Error should mention TARGET_ORGANIZATION, got: %v", err)
+	}
+}
+
+func TestCheckOrgVars_MissingSourceToken(t *testing.T) {
+	resetViperAndEnv()
+	defer resetViperAndEnv()
+
+	os.Setenv("GHMV_SOURCE_ORGANIZATION", "source-org")
+	os.Setenv("GHMV_TARGET_ORGANIZATION", "target-org")
+	os.Setenv("GHMV_TARGET_TOKEN", "token")
+
+	viper.SetEnvPrefix("GHMV")
+	viper.AutomaticEnv()
+
+	err := checkOrgVars()
+	if err == nil {
+		t.Error("Expected error when SOURCE_TOKEN is missing")
+	}
+	if !strings.Contains(err.Error(), "SOURCE_TOKEN") {
+		t.Errorf("Error should mention SOURCE_TOKEN, got: %v", err)
+	}
+}
+
+func TestCheckOrgVars_MissingTargetToken(t *testing.T) {
+	resetViperAndEnv()
+	defer resetViperAndEnv()
+
+	os.Setenv("GHMV_SOURCE_ORGANIZATION", "source-org")
+	os.Setenv("GHMV_TARGET_ORGANIZATION", "target-org")
+	os.Setenv("GHMV_SOURCE_TOKEN", "token")
+
+	viper.SetEnvPrefix("GHMV")
+	viper.AutomaticEnv()
+
+	err := checkOrgVars()
+	if err == nil {
+		t.Error("Expected error when TARGET_TOKEN is missing")
+	}
+	if !strings.Contains(err.Error(), "TARGET_TOKEN") {
+		t.Errorf("Error should mention TARGET_TOKEN, got: %v", err)
+	}
+}
+
+func TestCheckOrgVars_DoesNotRequireRepoFlags(t *testing.T) {
+	resetViperAndEnv()
+	defer resetViperAndEnv()
+
+	// Org validation should NOT require SOURCE_REPO / TARGET_REPO
+	os.Setenv("GHMV_SOURCE_ORGANIZATION", "source-org")
+	os.Setenv("GHMV_TARGET_ORGANIZATION", "target-org")
+	os.Setenv("GHMV_SOURCE_TOKEN", "token")
+	os.Setenv("GHMV_TARGET_TOKEN", "token")
+
+	viper.SetEnvPrefix("GHMV")
+	viper.AutomaticEnv()
+
+	err := checkOrgVars()
+	if err != nil {
+		t.Errorf("checkOrgVars should not require repo flags, got: %v", err)
+	}
+}
+
+func TestValidateOrgCommand_Registered(t *testing.T) {
+	// Verify the validate-org subcommand is registered on rootCmd
+	found := false
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Use == "validate-org" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("validate-org command should be registered as a subcommand of root")
+	}
+}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -294,6 +294,34 @@ func (api *GitHubAPI) ValidateRepoAccess(clientType ClientType, owner, name stri
 	return nil
 }
 
+// IsRepoFork checks whether a repository is a fork using a lightweight GraphQL query.
+func (api *GitHubAPI) IsRepoFork(clientType ClientType, owner, name string) (bool, error) {
+	ctx := context.Background()
+
+	var query struct {
+		Repository struct {
+			IsFork bool
+		} `graphql:"repository(owner: $owner, name: $name)"`
+	}
+
+	variables := map[string]interface{}{
+		"owner": githubv4.String(owner),
+		"name":  githubv4.String(name),
+	}
+
+	client, clientName, err := api.getGraphQLClient(clientType)
+	if err != nil {
+		return false, fmt.Errorf("failed to get %s client: %w", clientName, err)
+	}
+
+	err = client.client.Query(ctx, &query, variables)
+	if err != nil {
+		return false, fmt.Errorf("failed to check if %s repo %s/%s is a fork: %w", clientName, owner, name, err)
+	}
+
+	return query.Repository.IsFork, nil
+}
+
 // RateLimitInfo contains information about current rate limit status
 type RateLimitInfo struct {
 	Remaining int
@@ -770,8 +798,14 @@ func (api *GitHubAPI) DownloadMigrationArchive(clientType ClientType, org string
 	return outputPath, nil
 }
 
-// ListOrgRepos retrieves all repository names for an organization using GraphQL pagination.
-func (api *GitHubAPI) ListOrgRepos(clientType ClientType, org string) ([]string, error) {
+// OrgRepo holds basic repository info returned by ListOrgRepos.
+type OrgRepo struct {
+	Name   string
+	IsFork bool
+}
+
+// ListOrgRepos retrieves all repositories for an organization using GraphQL pagination.
+func (api *GitHubAPI) ListOrgRepos(clientType ClientType, org string) ([]OrgRepo, error) {
 	ctx := context.Background()
 
 	client, clientName, err := api.getGraphQLClient(clientType)
@@ -783,7 +817,8 @@ func (api *GitHubAPI) ListOrgRepos(clientType ClientType, org string) ([]string,
 		Organization struct {
 			Repositories struct {
 				Nodes []struct {
-					Name string
+					Name   string
+					IsFork bool
 				}
 				PageInfo struct {
 					HasNextPage bool
@@ -798,7 +833,7 @@ func (api *GitHubAPI) ListOrgRepos(clientType ClientType, org string) ([]string,
 		"cursor": (*githubv4.String)(nil),
 	}
 
-	var repos []string
+	var repos []OrgRepo
 	for {
 		err := client.Query(ctx, &query, variables)
 		if err != nil {
@@ -806,7 +841,7 @@ func (api *GitHubAPI) ListOrgRepos(clientType ClientType, org string) ([]string,
 		}
 
 		for _, node := range query.Organization.Repositories.Nodes {
-			repos = append(repos, node.Name)
+			repos = append(repos, OrgRepo{Name: node.Name, IsFork: node.IsFork})
 		}
 
 		if !query.Organization.Repositories.PageInfo.HasNextPage {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -770,6 +770,54 @@ func (api *GitHubAPI) DownloadMigrationArchive(clientType ClientType, org string
 	return outputPath, nil
 }
 
+// ListOrgRepos retrieves all repository names for an organization using GraphQL pagination.
+func (api *GitHubAPI) ListOrgRepos(clientType ClientType, org string) ([]string, error) {
+	ctx := context.Background()
+
+	client, clientName, err := api.getGraphQLClient(clientType)
+	if err != nil {
+		return nil, err
+	}
+
+	var query struct {
+		Organization struct {
+			Repositories struct {
+				Nodes []struct {
+					Name string
+				}
+				PageInfo struct {
+					HasNextPage bool
+					EndCursor   githubv4.String
+				}
+			} `graphql:"repositories(first: 100, after: $cursor)"`
+		} `graphql:"organization(login: $org)"`
+	}
+
+	variables := map[string]interface{}{
+		"org":    githubv4.String(org),
+		"cursor": (*githubv4.String)(nil),
+	}
+
+	var repos []string
+	for {
+		err := client.Query(ctx, &query, variables)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list %s organization repositories: %v", clientName, err)
+		}
+
+		for _, node := range query.Organization.Repositories.Nodes {
+			repos = append(repos, node.Name)
+		}
+
+		if !query.Organization.Repositories.PageInfo.HasNextPage {
+			break
+		}
+		variables["cursor"] = githubv4.NewString(query.Organization.Repositories.PageInfo.EndCursor)
+	}
+
+	return repos, nil
+}
+
 // Helper function to get client config for a given client type
 func getClientConfigForType(clientType ClientType) ClientConfig {
 	switch clientType {

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -1231,3 +1231,236 @@ func (mv *MigrationValidator) outputMarkdownResults(results []ValidationResult) 
 
 	pterm.Success.Printf("📁 Markdown report saved to %s\n", markdownFile)
 }
+
+// RepoValidationResult holds validation results for a single repository in org-level validation.
+type RepoValidationResult struct {
+	RepoName string
+	Results  []ValidationResult
+	Error    string // Non-empty if the repo validation failed entirely
+}
+
+// OrgValidationSummary holds the overall summary for an organization validation.
+type OrgValidationSummary struct {
+	SourceOrg string
+	TargetOrg string
+	Repos     []RepoValidationResult
+}
+
+// ValidateOrganization validates all repositories in the source org against the target org.
+// It produces a single consolidated report. Repos that fail are recorded with an error
+// but do not stop the rest of the validation.
+func (mv *MigrationValidator) ValidateOrganization(sourceOrg, targetOrg string, repoNames []string) *OrgValidationSummary {
+	summary := &OrgValidationSummary{
+		SourceOrg: sourceOrg,
+		TargetOrg: targetOrg,
+	}
+
+	for i, repoName := range repoNames {
+		pterm.DefaultSection.Printf("[%d/%d] Validating repository: %s\n", i+1, len(repoNames), repoName)
+
+		// Create a fresh validator for each repo to avoid state leaking
+		repoValidator := New(mv.api)
+		results, err := repoValidator.ValidateMigration(sourceOrg, repoName, targetOrg, repoName)
+
+		entry := RepoValidationResult{RepoName: repoName}
+		if err != nil {
+			entry.Error = err.Error()
+			pterm.Error.Printf("  %s: %v\n", repoName, err)
+		} else {
+			entry.Results = results
+		}
+		summary.Repos = append(summary.Repos, entry)
+	}
+
+	return summary
+}
+
+// PrintOrgValidationResults prints a consolidated org-level report.
+func PrintOrgValidationResults(summary *OrgValidationSummary) {
+	pterm.DefaultHeader.WithFullWidth().
+		WithBackgroundStyle(pterm.NewStyle(pterm.BgBlue)).
+		WithTextStyle(pterm.NewStyle(pterm.FgWhite)).
+		Println("📊 Organization Migration Validation Report")
+
+	fmt.Printf("Source org: %s  |  Target org: %s\n", summary.SourceOrg, summary.TargetOrg)
+	fmt.Printf("Repositories validated: %d\n\n", len(summary.Repos))
+
+	// Per-repo summary table
+	tableData := [][]string{{"Repository", "Status", "Pass", "Fail", "Warn"}}
+
+	totalPass, totalFail, totalWarn, totalErrors := 0, 0, 0, 0
+
+	for _, repo := range summary.Repos {
+		if repo.Error != "" {
+			tableData = append(tableData, []string{repo.RepoName, "❌ ERROR", "-", "-", "-"})
+			totalErrors++
+			continue
+		}
+
+		pass, fail, warn := 0, 0, 0
+		for _, r := range repo.Results {
+			switch r.StatusType {
+			case ValidationStatusPass:
+				pass++
+			case ValidationStatusFail:
+				fail++
+			case ValidationStatusWarn:
+				warn++
+			}
+		}
+
+		status := ValidationStatusMessagePass
+		if fail > 0 {
+			status = ValidationStatusMessageFail
+		} else if warn > 0 {
+			status = ValidationStatusMessageWarn
+		}
+
+		tableData = append(tableData, []string{
+			repo.RepoName,
+			status,
+			fmt.Sprintf("%d", pass),
+			fmt.Sprintf("%d", fail),
+			fmt.Sprintf("%d", warn),
+		})
+
+		totalPass += pass
+		totalFail += fail
+		totalWarn += warn
+	}
+
+	pterm.DefaultTable.WithHasHeader().WithData(tableData).Render()
+	fmt.Println()
+
+	// Overall summary
+	summaryItems := []pterm.BulletListItem{
+		{Level: 0, Text: fmt.Sprintf("Total checks passed: %d", totalPass), TextStyle: pterm.NewStyle(pterm.FgGreen)},
+		{Level: 0, Text: fmt.Sprintf("Total checks failed: %d", totalFail), TextStyle: pterm.NewStyle(pterm.FgRed)},
+		{Level: 0, Text: fmt.Sprintf("Total warnings: %d", totalWarn), TextStyle: pterm.NewStyle(pterm.FgYellow)},
+	}
+	if totalErrors > 0 {
+		summaryItems = append(summaryItems, pterm.BulletListItem{
+			Level: 0, Text: fmt.Sprintf("Repos with errors: %d", totalErrors), TextStyle: pterm.NewStyle(pterm.FgRed),
+		})
+	}
+	pterm.DefaultBulletList.WithItems(summaryItems).WithBullet("📊").Render()
+	fmt.Println()
+
+	if totalFail > 0 || totalErrors > 0 {
+		pterm.Error.Println("❌ Organization migration validation FAILED")
+	} else if totalWarn > 0 {
+		pterm.Warning.Println("⚠️ Organization migration validation completed with WARNINGS")
+	} else {
+		pterm.Success.Println("✅ Organization migration validation PASSED - All repositories match!")
+	}
+	fmt.Println()
+}
+
+// OrgHasFailures reports whether any repository in the org validation has failures or errors.
+func OrgHasFailures(summary *OrgValidationSummary) bool {
+	for _, repo := range summary.Repos {
+		if repo.Error != "" {
+			return true
+		}
+		if HasFailures(repo.Results) {
+			return true
+		}
+	}
+	return false
+}
+
+// WriteOrgMarkdownReport writes a consolidated markdown report for org-level validation.
+func WriteOrgMarkdownReport(summary *OrgValidationSummary, writer io.Writer) {
+	fmt.Fprintln(writer, "# Organization Migration Validation Report")
+	fmt.Fprintln(writer)
+	fmt.Fprintf(writer, "**Source Organization:** `%s`  \n", summary.SourceOrg)
+	fmt.Fprintf(writer, "**Target Organization:** `%s`  \n", summary.TargetOrg)
+	fmt.Fprintf(writer, "**Repositories validated:** %d  \n\n", len(summary.Repos))
+
+	// Summary table
+	fmt.Fprintln(writer, "## Summary")
+	fmt.Fprintln(writer)
+	fmt.Fprintln(writer, "| Repository | Status | Pass | Fail | Warn |")
+	fmt.Fprintln(writer, "|------------|--------|------|------|------|")
+
+	totalPass, totalFail, totalWarn, totalErrors := 0, 0, 0, 0
+
+	for _, repo := range summary.Repos {
+		if repo.Error != "" {
+			fmt.Fprintf(writer, "| %s | ❌ ERROR | - | - | - |\n", repo.RepoName)
+			totalErrors++
+			continue
+		}
+
+		pass, fail, warn := 0, 0, 0
+		for _, r := range repo.Results {
+			switch r.StatusType {
+			case ValidationStatusPass:
+				pass++
+			case ValidationStatusFail:
+				fail++
+			case ValidationStatusWarn:
+				warn++
+			}
+		}
+
+		status := ValidationStatusMessagePass
+		if fail > 0 {
+			status = ValidationStatusMessageFail
+		} else if warn > 0 {
+			status = ValidationStatusMessageWarn
+		}
+
+		fmt.Fprintf(writer, "| %s | %s | %d | %d | %d |\n", repo.RepoName, status, pass, fail, warn)
+		totalPass += pass
+		totalFail += fail
+		totalWarn += warn
+	}
+
+	fmt.Fprintln(writer)
+	fmt.Fprintf(writer, "**Total:** %d passed, %d failed, %d warnings", totalPass, totalFail, totalWarn)
+	if totalErrors > 0 {
+		fmt.Fprintf(writer, ", %d errors", totalErrors)
+	}
+	fmt.Fprintln(writer)
+	fmt.Fprintln(writer)
+
+	// Per-repo detail sections
+	for _, repo := range summary.Repos {
+		fmt.Fprintf(writer, "---\n\n### %s\n\n", repo.RepoName)
+
+		if repo.Error != "" {
+			fmt.Fprintf(writer, "**Error:** %s\n\n", repo.Error)
+			continue
+		}
+
+		fmt.Fprintln(writer, "| Metric | Status | Source Value | Target Value | Difference |")
+		fmt.Fprintln(writer, "|--------|--------|--------------|--------------|------------|")
+
+		for _, result := range repo.Results {
+			diffStr := ""
+			if result.Difference > 0 {
+				diffStr = fmt.Sprintf("Missing: %d", result.Difference)
+			} else if result.Difference < 0 {
+				diffStr = fmt.Sprintf("Extra: %d", -result.Difference)
+			} else if result.Metric == "Latest Commit SHA" {
+				diffStr = "N/A"
+			} else {
+				diffStr = "Perfect match"
+			}
+
+			fmt.Fprintf(writer, "| %s | %s | %v | %v | %s |\n",
+				result.Metric, result.Status, result.SourceVal, result.TargetVal, diffStr)
+		}
+		fmt.Fprintln(writer)
+	}
+
+	// Final result
+	if totalFail > 0 || totalErrors > 0 {
+		fmt.Fprintln(writer, "**Result:** ❌ Organization migration validation FAILED")
+	} else if totalWarn > 0 {
+		fmt.Fprintln(writer, "**Result:** ⚠️ Organization migration validation completed with WARNINGS")
+	} else {
+		fmt.Fprintln(writer, "**Result:** ✅ Organization migration validation PASSED - All repositories match!")
+	}
+}

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -117,8 +117,13 @@ func New(githubAPI *api.GitHubAPI) *MigrationValidator {
 	}
 }
 
-// ValidateMigration performs the migration validation logic and returns results
-func (mv *MigrationValidator) ValidateMigration(sourceOwner, sourceRepo, targetOwner, targetRepo string) ([]ValidationResult, error) {
+// ValidateMigration performs the migration validation logic and returns results.
+// An optional ValidationOptions can be passed to control which checks are performed.
+func (mv *MigrationValidator) ValidateMigration(sourceOwner, sourceRepo, targetOwner, targetRepo string, opts ...ValidationOptions) ([]ValidationResult, error) {
+	opt := ValidationOptions{}
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
 	// Validate access to both repositories before starting expensive operations
 	fmt.Println("Validating repository access...")
 	if err := mv.api.ValidateRepoAccess(api.SourceClient, sourceOwner, sourceRepo); err != nil {
@@ -184,7 +189,7 @@ func (mv *MigrationValidator) ValidateMigration(sourceOwner, sourceRepo, targetO
 
 	// Compare and validate the data
 	fmt.Println("\nValidating migration data...")
-	results := mv.validateRepositoryData(ValidationOptions{})
+	results := mv.validateRepositoryData(opt)
 
 	fmt.Println("Migration validation completed!")
 	return results, nil
@@ -1232,11 +1237,19 @@ func (mv *MigrationValidator) outputMarkdownResults(results []ValidationResult) 
 	pterm.Success.Printf("📁 Markdown report saved to %s\n", markdownFile)
 }
 
+// RepoMapping represents a source-to-target repository name pair.
+type RepoMapping struct {
+	SourceRepo string
+	TargetRepo string
+	IsFork     bool
+}
+
 // RepoValidationResult holds validation results for a single repository in org-level validation.
 type RepoValidationResult struct {
-	RepoName string
-	Results  []ValidationResult
-	Error    string // Non-empty if the repo validation failed entirely
+	SourceRepoName string
+	TargetRepoName string
+	Results        []ValidationResult
+	Error          string // Non-empty if the repo validation failed entirely
 }
 
 // OrgValidationSummary holds the overall summary for an organization validation.
@@ -1246,30 +1259,59 @@ type OrgValidationSummary struct {
 	Repos     []RepoValidationResult
 }
 
-// ValidateOrganization validates all repositories in the source org against the target org.
-// It produces a single consolidated report. Repos that fail are recorded with an error
-// but do not stop the rest of the validation.
-func (mv *MigrationValidator) ValidateOrganization(sourceOrg, targetOrg string, repoNames []string) *OrgValidationSummary {
+// ValidateOrganization validates repositories from the source org against the target org
+// using the provided repo mappings. Each mapping specifies a source and target repo name,
+// allowing different names between source and target. Repos that fail are recorded with
+// an error but do not stop the rest of the validation.
+// The optional onResult callback is invoked after each repo completes, enabling incremental
+// output (e.g. writing partial results to disk so progress survives Ctrl+C).
+func (mv *MigrationValidator) ValidateOrganization(sourceOrg, targetOrg string, mappings []RepoMapping, onResult func(*OrgValidationSummary)) *OrgValidationSummary {
 	summary := &OrgValidationSummary{
 		SourceOrg: sourceOrg,
 		TargetOrg: targetOrg,
 	}
 
-	for i, repoName := range repoNames {
-		pterm.DefaultSection.Printf("[%d/%d] Validating repository: %s\n", i+1, len(repoNames), repoName)
+	for i, mapping := range mappings {
+		label := mapping.SourceRepo
+		if mapping.SourceRepo != mapping.TargetRepo {
+			label = fmt.Sprintf("%s → %s", mapping.SourceRepo, mapping.TargetRepo)
+		}
+		pterm.DefaultSection.Printf("[%d/%d] Validating repository: %s\n", i+1, len(mappings), label)
 
 		// Create a fresh validator for each repo to avoid state leaking
 		repoValidator := New(mv.api)
-		results, err := repoValidator.ValidateMigration(sourceOrg, repoName, targetOrg, repoName)
 
-		entry := RepoValidationResult{RepoName: repoName}
+		// Detect if source repo is a fork (from ListOrgRepos or API check)
+		isFork := mapping.IsFork
+		if !isFork && mv.api != nil {
+			if detected, err := mv.api.IsRepoFork(api.SourceClient, sourceOrg, mapping.SourceRepo); err == nil {
+				isFork = detected
+			}
+		}
+
+		// Forked repos have issues disabled, skip issue validation for them
+		var opts ValidationOptions
+		if isFork {
+			opts.SkipIssues = true
+		}
+
+		results, err := repoValidator.ValidateMigration(sourceOrg, mapping.SourceRepo, targetOrg, mapping.TargetRepo, opts)
+
+		entry := RepoValidationResult{
+			SourceRepoName: mapping.SourceRepo,
+			TargetRepoName: mapping.TargetRepo,
+		}
 		if err != nil {
 			entry.Error = err.Error()
-			pterm.Error.Printf("  %s: %v\n", repoName, err)
+			pterm.Error.Printf("  %s: %v\n", label, err)
 		} else {
 			entry.Results = results
 		}
 		summary.Repos = append(summary.Repos, entry)
+
+		if onResult != nil {
+			onResult(summary)
+		}
 	}
 
 	return summary
@@ -1286,18 +1328,19 @@ func PrintOrgValidationResults(summary *OrgValidationSummary) {
 	fmt.Printf("Repositories validated: %d\n\n", len(summary.Repos))
 
 	// Per-repo summary table
-	tableData := [][]string{{"Repository", "Status", "Pass", "Fail", "Warn"}}
+	tableData := [][]string{{"Repository", "Status", "Pass", "Fail", "Warn", "Info"}}
 
-	totalPass, totalFail, totalWarn, totalErrors := 0, 0, 0, 0
+	totalPass, totalFail, totalWarn, totalInfo, totalErrors := 0, 0, 0, 0, 0
 
 	for _, repo := range summary.Repos {
+		repoLabel := orgRepoLabel(repo)
 		if repo.Error != "" {
-			tableData = append(tableData, []string{repo.RepoName, "❌ ERROR", "-", "-", "-"})
+			tableData = append(tableData, []string{repoLabel, "❌ ERROR", "-", "-", "-", "-"})
 			totalErrors++
 			continue
 		}
 
-		pass, fail, warn := 0, 0, 0
+		pass, fail, warn, info := 0, 0, 0, 0
 		for _, r := range repo.Results {
 			switch r.StatusType {
 			case ValidationStatusPass:
@@ -1306,6 +1349,8 @@ func PrintOrgValidationResults(summary *OrgValidationSummary) {
 				fail++
 			case ValidationStatusWarn:
 				warn++
+			case ValidationStatusInfo:
+				info++
 			}
 		}
 
@@ -1317,16 +1362,18 @@ func PrintOrgValidationResults(summary *OrgValidationSummary) {
 		}
 
 		tableData = append(tableData, []string{
-			repo.RepoName,
+			repoLabel,
 			status,
 			fmt.Sprintf("%d", pass),
 			fmt.Sprintf("%d", fail),
 			fmt.Sprintf("%d", warn),
+			fmt.Sprintf("%d", info),
 		})
 
 		totalPass += pass
 		totalFail += fail
 		totalWarn += warn
+		totalInfo += info
 	}
 
 	pterm.DefaultTable.WithHasHeader().WithData(tableData).Render()
@@ -1337,6 +1384,11 @@ func PrintOrgValidationResults(summary *OrgValidationSummary) {
 		{Level: 0, Text: fmt.Sprintf("Total checks passed: %d", totalPass), TextStyle: pterm.NewStyle(pterm.FgGreen)},
 		{Level: 0, Text: fmt.Sprintf("Total checks failed: %d", totalFail), TextStyle: pterm.NewStyle(pterm.FgRed)},
 		{Level: 0, Text: fmt.Sprintf("Total warnings: %d", totalWarn), TextStyle: pterm.NewStyle(pterm.FgYellow)},
+	}
+	if totalInfo > 0 {
+		summaryItems = append(summaryItems, pterm.BulletListItem{
+			Level: 0, Text: fmt.Sprintf("Total info: %d", totalInfo), TextStyle: pterm.NewStyle(pterm.FgCyan),
+		})
 	}
 	if totalErrors > 0 {
 		summaryItems = append(summaryItems, pterm.BulletListItem{
@@ -1369,6 +1421,69 @@ func OrgHasFailures(summary *OrgValidationSummary) bool {
 	return false
 }
 
+// orgRepoLabel returns a display label for a repo in org validation.
+// Shows "source → target" when names differ, otherwise just the repo name.
+func orgRepoLabel(repo RepoValidationResult) string {
+	if repo.SourceRepoName != repo.TargetRepoName {
+		return fmt.Sprintf("%s → %s", repo.SourceRepoName, repo.TargetRepoName)
+	}
+	return repo.SourceRepoName
+}
+
+// ParseRepoListCSV parses a CSV file with source,target repo mappings.
+// Expected format (with optional header): source_repo,target_repo
+// Lines starting with # are treated as comments and skipped.
+// If a line has only one column, the target is assumed to be the same as source.
+func ParseRepoListCSV(filePath string) ([]RepoMapping, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read repo list file: %w", err)
+	}
+
+	var mappings []RepoMapping
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+
+	headerSkipped := false
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		// Skip header row (first non-empty, non-comment line that looks like a header)
+		if !headerSkipped {
+			lower := strings.ToLower(line)
+			if strings.Contains(lower, "source") && strings.Contains(lower, "target") {
+				headerSkipped = true
+				continue
+			}
+			headerSkipped = true
+		}
+
+		parts := strings.SplitN(line, ",", 2)
+		source := strings.TrimSpace(parts[0])
+		if source == "" {
+			continue
+		}
+
+		target := source // default: same name
+		if len(parts) == 2 {
+			t := strings.TrimSpace(parts[1])
+			if t != "" {
+				target = t
+			}
+		}
+
+		mappings = append(mappings, RepoMapping{SourceRepo: source, TargetRepo: target})
+	}
+
+	if len(mappings) == 0 {
+		return nil, fmt.Errorf("no repository mappings found in %s", filePath)
+	}
+
+	return mappings, nil
+}
+
 // WriteOrgMarkdownReport writes a consolidated markdown report for org-level validation.
 func WriteOrgMarkdownReport(summary *OrgValidationSummary, writer io.Writer) {
 	fmt.Fprintln(writer, "# Organization Migration Validation Report")
@@ -1380,19 +1495,20 @@ func WriteOrgMarkdownReport(summary *OrgValidationSummary, writer io.Writer) {
 	// Summary table
 	fmt.Fprintln(writer, "## Summary")
 	fmt.Fprintln(writer)
-	fmt.Fprintln(writer, "| Repository | Status | Pass | Fail | Warn |")
-	fmt.Fprintln(writer, "|------------|--------|------|------|------|")
+	fmt.Fprintln(writer, "| Repository | Status | Pass | Fail | Warn | Info |")
+	fmt.Fprintln(writer, "|------------|--------|------|------|------|------|")
 
-	totalPass, totalFail, totalWarn, totalErrors := 0, 0, 0, 0
+	totalPass, totalFail, totalWarn, totalInfo, totalErrors := 0, 0, 0, 0, 0
 
 	for _, repo := range summary.Repos {
+		repoLabel := orgRepoLabel(repo)
 		if repo.Error != "" {
-			fmt.Fprintf(writer, "| %s | ❌ ERROR | - | - | - |\n", repo.RepoName)
+			fmt.Fprintf(writer, "| %s | ❌ ERROR | - | - | - | - |\n", repoLabel)
 			totalErrors++
 			continue
 		}
 
-		pass, fail, warn := 0, 0, 0
+		pass, fail, warn, info := 0, 0, 0, 0
 		for _, r := range repo.Results {
 			switch r.StatusType {
 			case ValidationStatusPass:
@@ -1401,6 +1517,8 @@ func WriteOrgMarkdownReport(summary *OrgValidationSummary, writer io.Writer) {
 				fail++
 			case ValidationStatusWarn:
 				warn++
+			case ValidationStatusInfo:
+				info++
 			}
 		}
 
@@ -1411,14 +1529,18 @@ func WriteOrgMarkdownReport(summary *OrgValidationSummary, writer io.Writer) {
 			status = ValidationStatusMessageWarn
 		}
 
-		fmt.Fprintf(writer, "| %s | %s | %d | %d | %d |\n", repo.RepoName, status, pass, fail, warn)
+		fmt.Fprintf(writer, "| %s | %s | %d | %d | %d | %d |\n", repoLabel, status, pass, fail, warn, info)
 		totalPass += pass
 		totalFail += fail
 		totalWarn += warn
+		totalInfo += info
 	}
 
 	fmt.Fprintln(writer)
 	fmt.Fprintf(writer, "**Total:** %d passed, %d failed, %d warnings", totalPass, totalFail, totalWarn)
+	if totalInfo > 0 {
+		fmt.Fprintf(writer, ", %d info", totalInfo)
+	}
 	if totalErrors > 0 {
 		fmt.Fprintf(writer, ", %d errors", totalErrors)
 	}
@@ -1427,7 +1549,7 @@ func WriteOrgMarkdownReport(summary *OrgValidationSummary, writer io.Writer) {
 
 	// Per-repo detail sections
 	for _, repo := range summary.Repos {
-		fmt.Fprintf(writer, "---\n\n### %s\n\n", repo.RepoName)
+		fmt.Fprintf(writer, "---\n\n### %s\n\n", orgRepoLabel(repo))
 
 		if repo.Error != "" {
 			fmt.Fprintf(writer, "**Error:** %s\n\n", repo.Error)

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -1241,7 +1241,7 @@ func (mv *MigrationValidator) outputMarkdownResults(results []ValidationResult) 
 type RepoMapping struct {
 	SourceRepo string
 	TargetRepo string
-	IsFork     bool
+	IsFork     *bool // nil = unknown (will query API), non-nil = known from ListOrgRepos
 }
 
 // RepoValidationResult holds validation results for a single repository in org-level validation.
@@ -1282,8 +1282,10 @@ func (mv *MigrationValidator) ValidateOrganization(sourceOrg, targetOrg string, 
 		repoValidator := New(mv.api)
 
 		// Detect if source repo is a fork (from ListOrgRepos or API check)
-		isFork := mapping.IsFork
-		if !isFork && mv.api != nil {
+		isFork := false
+		if mapping.IsFork != nil {
+			isFork = *mapping.IsFork
+		} else if mv.api != nil {
 			if detected, err := mv.api.IsRepoFork(api.SourceClient, sourceOrg, mapping.SourceRepo); err == nil {
 				isFork = detected
 			}
@@ -1450,14 +1452,13 @@ func ParseRepoListCSV(filePath string) ([]RepoMapping, error) {
 			continue
 		}
 
-		// Skip header row (first non-empty, non-comment line that looks like a header)
+		// Skip header row: must exactly match known header patterns
 		if !headerSkipped {
+			headerSkipped = true
 			lower := strings.ToLower(line)
-			if strings.Contains(lower, "source") && strings.Contains(lower, "target") {
-				headerSkipped = true
+			if lower == "source_repo,target_repo" || lower == "source,target" {
 				continue
 			}
-			headerSkipped = true
 		}
 
 		parts := strings.SplitN(line, ",", 2)

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -1293,6 +1293,18 @@ func TestParseRepoListCSV_FileNotFound(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestParseRepoListCSV_RepoNameContainsSourceTarget(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "repos.csv")
+	content := "source_repo,target_repo\nmy-source-app,my-target-app\n"
+	os.WriteFile(tmpFile, []byte(content), 0o644)
+
+	mappings, err := ParseRepoListCSV(tmpFile)
+	assert.NoError(t, err)
+	assert.Len(t, mappings, 1)
+	assert.Equal(t, "my-source-app", mappings[0].SourceRepo)
+	assert.Equal(t, "my-target-app", mappings[0].TargetRepo)
+}
+
 func TestOrgRepoLabel_SameName(t *testing.T) {
 	repo := RepoValidationResult{SourceRepoName: "my-repo", TargetRepoName: "my-repo"}
 	assert.Equal(t, "my-repo", orgRepoLabel(repo))

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -1053,3 +1053,180 @@ func TestValidateRepositoryData_NoLFSFlag(t *testing.T) {
 			"Metric at position %d should be %s", i, expectedMetric)
 	}
 }
+
+func TestOrgHasFailures_NoFailures(t *testing.T) {
+	summary := &OrgValidationSummary{
+		SourceOrg: "source-org",
+		TargetOrg: "target-org",
+		Repos: []RepoValidationResult{
+			{
+				RepoName: "repo-a",
+				Results: []ValidationResult{
+					{Metric: "Issues", StatusType: ValidationStatusPass},
+					{Metric: "Tags", StatusType: ValidationStatusPass},
+				},
+			},
+			{
+				RepoName: "repo-b",
+				Results: []ValidationResult{
+					{Metric: "Issues", StatusType: ValidationStatusWarn},
+				},
+			},
+		},
+	}
+
+	assert.False(t, OrgHasFailures(summary), "Should report no failures when all repos pass or warn")
+}
+
+func TestOrgHasFailures_WithFailedValidation(t *testing.T) {
+	summary := &OrgValidationSummary{
+		SourceOrg: "source-org",
+		TargetOrg: "target-org",
+		Repos: []RepoValidationResult{
+			{
+				RepoName: "repo-a",
+				Results: []ValidationResult{
+					{Metric: "Issues", StatusType: ValidationStatusPass},
+				},
+			},
+			{
+				RepoName: "repo-b",
+				Results: []ValidationResult{
+					{Metric: "Issues", StatusType: ValidationStatusFail},
+				},
+			},
+		},
+	}
+
+	assert.True(t, OrgHasFailures(summary), "Should report failures when a repo has failed validations")
+}
+
+func TestOrgHasFailures_WithRepoError(t *testing.T) {
+	summary := &OrgValidationSummary{
+		SourceOrg: "source-org",
+		TargetOrg: "target-org",
+		Repos: []RepoValidationResult{
+			{
+				RepoName: "repo-a",
+				Results: []ValidationResult{
+					{Metric: "Issues", StatusType: ValidationStatusPass},
+				},
+			},
+			{
+				RepoName: "repo-b",
+				Error:    "cannot access repository",
+			},
+		},
+	}
+
+	assert.True(t, OrgHasFailures(summary), "Should report failures when a repo has an error")
+}
+
+func TestOrgHasFailures_EmptyRepos(t *testing.T) {
+	summary := &OrgValidationSummary{
+		SourceOrg: "source-org",
+		TargetOrg: "target-org",
+		Repos:     []RepoValidationResult{},
+	}
+
+	assert.False(t, OrgHasFailures(summary), "Should report no failures for empty repo list")
+}
+
+func TestWriteOrgMarkdownReport(t *testing.T) {
+	summary := &OrgValidationSummary{
+		SourceOrg: "source-org",
+		TargetOrg: "target-org",
+		Repos: []RepoValidationResult{
+			{
+				RepoName: "repo-a",
+				Results: []ValidationResult{
+					{Metric: "Issues", Status: ValidationStatusMessagePass, StatusType: ValidationStatusPass, SourceVal: 10, TargetVal: 11, Difference: 0},
+					{Metric: "Tags", Status: ValidationStatusMessageFail, StatusType: ValidationStatusFail, SourceVal: 5, TargetVal: 3, Difference: 2},
+				},
+			},
+			{
+				RepoName: "repo-b",
+				Error:    "cannot access repository",
+			},
+			{
+				RepoName: "repo-c",
+				Results: []ValidationResult{
+					{Metric: "Issues", Status: ValidationStatusMessagePass, StatusType: ValidationStatusPass, SourceVal: 1, TargetVal: 2, Difference: 0},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	WriteOrgMarkdownReport(summary, &buf)
+	output := buf.String()
+
+	// Header
+	assert.Contains(t, output, "# Organization Migration Validation Report")
+	assert.Contains(t, output, "`source-org`")
+	assert.Contains(t, output, "`target-org`")
+	assert.Contains(t, output, "Repositories validated:** 3")
+
+	// Summary table
+	assert.Contains(t, output, "| repo-a |")
+	assert.Contains(t, output, "| repo-b | ❌ ERROR")
+	assert.Contains(t, output, "| repo-c |")
+
+	// Per-repo details
+	assert.Contains(t, output, "### repo-a")
+	assert.Contains(t, output, "### repo-b")
+	assert.Contains(t, output, "cannot access repository")
+	assert.Contains(t, output, "### repo-c")
+
+	// Detail table content
+	assert.Contains(t, output, "Missing: 2")
+
+	// Final result
+	assert.Contains(t, output, "FAILED")
+}
+
+func TestWriteOrgMarkdownReport_AllPass(t *testing.T) {
+	summary := &OrgValidationSummary{
+		SourceOrg: "src",
+		TargetOrg: "tgt",
+		Repos: []RepoValidationResult{
+			{
+				RepoName: "repo-a",
+				Results: []ValidationResult{
+					{Metric: "Issues", Status: ValidationStatusMessagePass, StatusType: ValidationStatusPass, SourceVal: 1, TargetVal: 1, Difference: 0},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	WriteOrgMarkdownReport(summary, &buf)
+
+	assert.Contains(t, buf.String(), "PASSED")
+	assert.NotContains(t, buf.String(), "FAILED")
+}
+
+func TestPrintOrgValidationResults_NoPanic(t *testing.T) {
+	summary := &OrgValidationSummary{
+		SourceOrg: "source-org",
+		TargetOrg: "target-org",
+		Repos: []RepoValidationResult{
+			{
+				RepoName: "repo-a",
+				Results: []ValidationResult{
+					{Metric: "Issues", Status: ValidationStatusMessagePass, StatusType: ValidationStatusPass, SourceVal: 1, TargetVal: 1},
+				},
+			},
+			{
+				RepoName: "repo-b",
+				Error:    "access denied",
+			},
+		},
+	}
+
+	assert.NotPanics(t, func() {
+		captureOutput(func() {
+			PrintOrgValidationResults(summary)
+		})
+	}, "PrintOrgValidationResults should not panic")
+}

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -1060,14 +1060,16 @@ func TestOrgHasFailures_NoFailures(t *testing.T) {
 		TargetOrg: "target-org",
 		Repos: []RepoValidationResult{
 			{
-				RepoName: "repo-a",
+				SourceRepoName: "repo-a",
+				TargetRepoName: "repo-a",
 				Results: []ValidationResult{
 					{Metric: "Issues", StatusType: ValidationStatusPass},
 					{Metric: "Tags", StatusType: ValidationStatusPass},
 				},
 			},
 			{
-				RepoName: "repo-b",
+				SourceRepoName: "repo-b",
+				TargetRepoName: "repo-b",
 				Results: []ValidationResult{
 					{Metric: "Issues", StatusType: ValidationStatusWarn},
 				},
@@ -1084,13 +1086,15 @@ func TestOrgHasFailures_WithFailedValidation(t *testing.T) {
 		TargetOrg: "target-org",
 		Repos: []RepoValidationResult{
 			{
-				RepoName: "repo-a",
+				SourceRepoName: "repo-a",
+				TargetRepoName: "repo-a",
 				Results: []ValidationResult{
 					{Metric: "Issues", StatusType: ValidationStatusPass},
 				},
 			},
 			{
-				RepoName: "repo-b",
+				SourceRepoName: "repo-b",
+				TargetRepoName: "repo-b",
 				Results: []ValidationResult{
 					{Metric: "Issues", StatusType: ValidationStatusFail},
 				},
@@ -1107,14 +1111,16 @@ func TestOrgHasFailures_WithRepoError(t *testing.T) {
 		TargetOrg: "target-org",
 		Repos: []RepoValidationResult{
 			{
-				RepoName: "repo-a",
+				SourceRepoName: "repo-a",
+				TargetRepoName: "repo-a",
 				Results: []ValidationResult{
 					{Metric: "Issues", StatusType: ValidationStatusPass},
 				},
 			},
 			{
-				RepoName: "repo-b",
-				Error:    "cannot access repository",
+				SourceRepoName: "repo-b",
+				TargetRepoName: "repo-b",
+				Error:          "cannot access repository",
 			},
 		},
 	}
@@ -1138,18 +1144,21 @@ func TestWriteOrgMarkdownReport(t *testing.T) {
 		TargetOrg: "target-org",
 		Repos: []RepoValidationResult{
 			{
-				RepoName: "repo-a",
+				SourceRepoName: "repo-a",
+				TargetRepoName: "repo-a",
 				Results: []ValidationResult{
 					{Metric: "Issues", Status: ValidationStatusMessagePass, StatusType: ValidationStatusPass, SourceVal: 10, TargetVal: 11, Difference: 0},
 					{Metric: "Tags", Status: ValidationStatusMessageFail, StatusType: ValidationStatusFail, SourceVal: 5, TargetVal: 3, Difference: 2},
 				},
 			},
 			{
-				RepoName: "repo-b",
-				Error:    "cannot access repository",
+				SourceRepoName: "repo-b",
+				TargetRepoName: "repo-b",
+				Error:          "cannot access repository",
 			},
 			{
-				RepoName: "repo-c",
+				SourceRepoName: "repo-c",
+				TargetRepoName: "repo-c",
 				Results: []ValidationResult{
 					{Metric: "Issues", Status: ValidationStatusMessagePass, StatusType: ValidationStatusPass, SourceVal: 1, TargetVal: 2, Difference: 0},
 				},
@@ -1191,7 +1200,8 @@ func TestWriteOrgMarkdownReport_AllPass(t *testing.T) {
 		TargetOrg: "tgt",
 		Repos: []RepoValidationResult{
 			{
-				RepoName: "repo-a",
+				SourceRepoName: "repo-a",
+				TargetRepoName: "repo-a",
 				Results: []ValidationResult{
 					{Metric: "Issues", Status: ValidationStatusMessagePass, StatusType: ValidationStatusPass, SourceVal: 1, TargetVal: 1, Difference: 0},
 				},
@@ -1212,14 +1222,16 @@ func TestPrintOrgValidationResults_NoPanic(t *testing.T) {
 		TargetOrg: "target-org",
 		Repos: []RepoValidationResult{
 			{
-				RepoName: "repo-a",
+				SourceRepoName: "repo-a",
+				TargetRepoName: "repo-a",
 				Results: []ValidationResult{
 					{Metric: "Issues", Status: ValidationStatusMessagePass, StatusType: ValidationStatusPass, SourceVal: 1, TargetVal: 1},
 				},
 			},
 			{
-				RepoName: "repo-b",
-				Error:    "access denied",
+				SourceRepoName: "repo-b",
+				TargetRepoName: "repo-b",
+				Error:          "access denied",
 			},
 		},
 	}
@@ -1229,4 +1241,110 @@ func TestPrintOrgValidationResults_NoPanic(t *testing.T) {
 			PrintOrgValidationResults(summary)
 		})
 	}, "PrintOrgValidationResults should not panic")
+}
+
+func TestParseRepoListCSV_BasicMapping(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "repos.csv")
+	content := "source_repo,target_repo\nmy-app,my-app-migrated\nshared-lib,shared-lib\n"
+	os.WriteFile(tmpFile, []byte(content), 0o644)
+
+	mappings, err := ParseRepoListCSV(tmpFile)
+	assert.NoError(t, err)
+	assert.Len(t, mappings, 2)
+	assert.Equal(t, "my-app", mappings[0].SourceRepo)
+	assert.Equal(t, "my-app-migrated", mappings[0].TargetRepo)
+	assert.Equal(t, "shared-lib", mappings[1].SourceRepo)
+	assert.Equal(t, "shared-lib", mappings[1].TargetRepo)
+}
+
+func TestParseRepoListCSV_SingleColumn(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "repos.csv")
+	content := "repo-a\nrepo-b\n"
+	os.WriteFile(tmpFile, []byte(content), 0o644)
+
+	mappings, err := ParseRepoListCSV(tmpFile)
+	assert.NoError(t, err)
+	assert.Len(t, mappings, 2)
+	assert.Equal(t, "repo-a", mappings[0].SourceRepo)
+	assert.Equal(t, "repo-a", mappings[0].TargetRepo)
+}
+
+func TestParseRepoListCSV_CommentsAndEmpty(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "repos.csv")
+	content := "# This is a comment\nsource_repo,target_repo\n\nmy-app,my-app\n# another comment\nlib,lib\n"
+	os.WriteFile(tmpFile, []byte(content), 0o644)
+
+	mappings, err := ParseRepoListCSV(tmpFile)
+	assert.NoError(t, err)
+	assert.Len(t, mappings, 2)
+}
+
+func TestParseRepoListCSV_EmptyFile(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "repos.csv")
+	os.WriteFile(tmpFile, []byte(""), 0o644)
+
+	_, err := ParseRepoListCSV(tmpFile)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no repository mappings found")
+}
+
+func TestParseRepoListCSV_FileNotFound(t *testing.T) {
+	_, err := ParseRepoListCSV("/nonexistent/file.csv")
+	assert.Error(t, err)
+}
+
+func TestOrgRepoLabel_SameName(t *testing.T) {
+	repo := RepoValidationResult{SourceRepoName: "my-repo", TargetRepoName: "my-repo"}
+	assert.Equal(t, "my-repo", orgRepoLabel(repo))
+}
+
+func TestOrgRepoLabel_DifferentNames(t *testing.T) {
+	repo := RepoValidationResult{SourceRepoName: "old-name", TargetRepoName: "new-name"}
+	assert.Equal(t, "old-name → new-name", orgRepoLabel(repo))
+}
+
+func TestWriteOrgMarkdownReport_WithInfoStatus(t *testing.T) {
+	summary := &OrgValidationSummary{
+		SourceOrg: "src",
+		TargetOrg: "tgt",
+		Repos: []RepoValidationResult{
+			{
+				SourceRepoName: "repo-a",
+				TargetRepoName: "repo-a",
+				Results: []ValidationResult{
+					{Metric: "Issues", Status: ValidationStatusMessagePass, StatusType: ValidationStatusPass, SourceVal: 1, TargetVal: 1, Difference: 0},
+					{Metric: "Branch Protection (advisory)", Status: ValidationStatusMessageInfo, StatusType: ValidationStatusInfo, SourceVal: 2, TargetVal: 1, Difference: 1},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	WriteOrgMarkdownReport(summary, &buf)
+	output := buf.String()
+
+	assert.Contains(t, output, "Info")
+	assert.Contains(t, output, "1 info")
+}
+
+func TestWriteOrgMarkdownReport_RepoMapping(t *testing.T) {
+	summary := &OrgValidationSummary{
+		SourceOrg: "src",
+		TargetOrg: "tgt",
+		Repos: []RepoValidationResult{
+			{
+				SourceRepoName: "old-name",
+				TargetRepoName: "new-name",
+				Results: []ValidationResult{
+					{Metric: "Issues", Status: ValidationStatusMessagePass, StatusType: ValidationStatusPass, SourceVal: 1, TargetVal: 1, Difference: 0},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	WriteOrgMarkdownReport(summary, &buf)
+	output := buf.String()
+
+	assert.Contains(t, output, "old-name → new-name")
 }


### PR DESCRIPTION
## Description

Add a new `validate-org` subcommand that validates all repositories in a source GitHub organization against a target organization in a single run. Instead of running validation per repository, it produces one consolidated report with a summary table and optional markdown output.

Changes:
- `ListOrgRepos` API method (GraphQL with pagination)
- `ValidateOrganization` + `PrintOrgValidationResults` + `WriteOrgMarkdownReport` in validator
- New `validate-org` CLI command
- README documentation

## Checklist

- [x] I have added the appropriate label to this PR according to the type of change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests

## Additional Context

Usage:
```bash
gh migration-validator validate-org \
  -s source-org -t target-org \
  -a "$SOURCE_TOKEN" -b "$TARGET_TOKEN" \
  --markdown-file report.md